### PR TITLE
Linux: Enable Prolific PL2023 serial port driver for GPS

### DIFF
--- a/recipes-kernel/linux/linux-stable-4.19/beaglebone/defconfig
+++ b/recipes-kernel/linux/linux-stable-4.19/beaglebone/defconfig
@@ -2817,6 +2817,14 @@ CONFIG_USB_SERIAL_FTDI_SIO=y
 # Met One 83000
 CONFIG_USB_SERIAL_CP210X=y
 
+# Enable USB Prolific 2303 Single Port Serial Driver
+#
+# Required by the following hardware:
+#
+#   - GlobalSat BU-353-S4 USB GPS Receiver
+#
+CONFIG_USB_SERIAL_PL2303=y
+
 #
 # USB Miscellaneous drivers
 #


### PR DESCRIPTION
## Description

This PR enables the linux driver used by the GlobalSat BU-353-S4 receiver.

## How has this been tested?

Tested with GlobalSat BU-353-S4 receiver on Sundström 1.0 Alpha 2. GPS coordinates are retrieved successfully.