### PR TITLE
kernel: 4.19.24

### DIFF
--- a/recipes-kernel/linux/linux-stable_4.19.bb
+++ b/recipes-kernel/linux/linux-stable_4.19.bb
@@ -17,8 +17,8 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/linux-stable-${LINUX_VERSION}:"
 
 S = "${WORKDIR}/git"
 
-PV = "4.19.0"
-SRCREV = "84df9525b0c27f3ebc2ebb1864fa62a97fdedb7d"
+PV = "4.19.24"
+SRCREV = "f287634fe3211277f078092bf57dc2b2a2e38dda"
 SRC_URI = " \
     git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git;branch=linux-${LINUX_VERSION}.y \
     file://defconfig \


### PR DESCRIPTION
## Description

This bumps the Linux kernel to the latest 4.19 release. The motivation is to bump the version to test OTA kernel updates.

## How has this been tested?

Tested on Sundström 1.0 Alpha 3 development build. Verified that it boots and GPS data can be read over the GPS serial port.