### PR TITLE
linux: Enable serial console on UART2

### DIFF
--- a/recipes-kernel/linux/linux-stable-4.20/dts-Add-uart2-node-on-BeagleBone-Black.patch
+++ b/recipes-kernel/linux/linux-stable-4.20/dts-Add-uart2-node-on-BeagleBone-Black.patch
@@ -1,0 +1,43 @@
+From 9ea43b4a7b31c33de27336d8ad292cb2f8d7c7c1 Mon Sep 17 00:00:00 2001
+From: Garrett Brown <garrett.brown@aclima.io>
+Date: Wed, 6 Mar 2019 14:17:47 -0800
+Subject: [PATCH] dts: Add uart2 node on BeagleBone Black
+
+---
+ arch/arm/boot/dts/am335x-boneblack-common.dtsi | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/arch/arm/boot/dts/am335x-boneblack-common.dtsi b/arch/arm/boot/dts/am335x-boneblack-common.dtsi
+index e543c2bee8c2..24485865351b 100644
+--- a/arch/arm/boot/dts/am335x-boneblack-common.dtsi
++++ b/arch/arm/boot/dts/am335x-boneblack-common.dtsi
+@@ -28,6 +28,13 @@
+ };
+ 
+ &am33xx_pinmux {
++	uart2_pins: uart2_pins {
++		pinctrl-single,pins = <
++			AM33XX_IOPAD(0x950, PIN_INPUT | MUX_MODE1)	/* spi0_sclk.uart2_rxd */
++			AM33XX_IOPAD(0x954, PIN_OUTPUT | MUX_MODE1)	/* spi0_d0.uart2_txd */
++		>;
++	};
++
+ 	nxp_hdmi_bonelt_pins: nxp_hdmi_bonelt_pins {
+ 		pinctrl-single,pins = <
+ 			AM33XX_IOPAD(0x9b0, PIN_OUTPUT_PULLDOWN | MUX_MODE3)	/* xdma_event_intr0 */
+@@ -71,6 +78,12 @@
+ 	};
+ };
+ 
++&uart2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart2_pins>;
++	status = "okay";
++};
++
+ &lcdc {
+ 	status = "okay";
+ 
+-- 
+2.17.1
+

--- a/recipes-kernel/linux/linux-stable_4.20.bb
+++ b/recipes-kernel/linux/linux-stable_4.20.bb
@@ -27,4 +27,5 @@ SRC_URI = " \
     file://0001-spidev-Add-a-generic-compatible-id.patch \
     file://0003-wlcore-Change-NO-FW-RX-BA-session-warnings-to-debug.patch \
     file://dts-Define-hardware-on-i2c2-bus.patch \
+    file://dts-Add-uart2-node-on-BeagleBone-Black.patch \
 "


### PR DESCRIPTION
## Description

This PR enables the ability to connect a serial console to the P9 header on the BeagleBone.

## How has this been tested?

Tested as part of Sundstrom 1.0 Alpha 4 build. See https://github.com/Aclima/sundstrom-os/pull/5.