### PR TITLE
u-boot: Revert patch to 2018.05

### DIFF
--- a/recipes-bsp/u-boot/files/0001-Customize-config-and-boot-command.patch
+++ b/recipes-bsp/u-boot/files/0001-Customize-config-and-boot-command.patch
@@ -1,84 +1,25 @@
-From 346e7359966093507c5e6cc28a5846670c003ca8 Mon Sep 17 00:00:00 2001
+From c19d240ead89f5225584b1c3865ad18e7801339e Mon Sep 17 00:00:00 2001
 From: Scott Ellis <scott@jumpnowtek.com>
 Date: Thu, 1 Nov 2018 05:01:35 -0400
 Subject: [PATCH] Customize config and boot command
 
 ---
- configs/am335x_boneblack_defconfig | 47 +++++++++++++++-----------------------
- 1 file changed, 19 insertions(+), 28 deletions(-)
+ configs/am335x_boneblack_defconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/configs/am335x_boneblack_defconfig b/configs/am335x_boneblack_defconfig
-index 732cb64..63675f0 100644
+index 5c01b20dff..6698008f40 100644
 --- a/configs/am335x_boneblack_defconfig
 +++ b/configs/am335x_boneblack_defconfig
-@@ -4,14 +4,14 @@ CONFIG_TI_COMMON_CMD_OPTIONS=y
- CONFIG_AM33XX=y
+@@ -6,7 +6,7 @@ CONFIG_AM33XX=y
  CONFIG_SPL=y
  CONFIG_DISTRO_DEFAULTS=y
--CONFIG_SYS_EXTRA_OPTIONS="EMMC_BOOT"
+ CONFIG_SYS_EXTRA_OPTIONS="EMMC_BOOT"
 -CONFIG_BOOTCOMMAND="if test ${boot_fit} -eq 1; then run update_to_fit; fi; run findfdt; run init_console; run envboot; run distro_bootcmd"
-+# CONFIG_SYS_EXTRA_OPTIONS="EMMC_BOOT"
 +CONFIG_BOOTCOMMAND="run envboot; setenv mmcdev 1; run envboot; setenv mmcdev 0; run findfdt; run distro_bootcmd"
  CONFIG_SYS_CONSOLE_INFO_QUIET=y
  CONFIG_VERSION_VARIABLE=y
  CONFIG_ARCH_MISC_INIT=y
--CONFIG_SPL_MUSB_NEW_SUPPORT=y
-+# CONFIG_SPL_MUSB_NEW_SUPPORT is not set
- # CONFIG_SPL_NAND_SUPPORT is not set
--CONFIG_SPL_OS_BOOT=y
-+# CONFIG_SPL_OS_BOOT is not set
- CONFIG_AUTOBOOT_KEYED=y
- CONFIG_AUTOBOOT_PROMPT="Press SPACE to abort autoboot in %d seconds\n"
- CONFIG_AUTOBOOT_DELAY_STR="d"
-@@ -19,33 +19,24 @@ CONFIG_AUTOBOOT_STOP_STR=" "
- CONFIG_CMD_SPL=y
- # CONFIG_CMD_FLASH is not set
- # CONFIG_CMD_SETEXPR is not set
--CONFIG_ENV_IS_IN_MMC=y
--CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
--CONFIG_BOOTCOUNT_LIMIT=y
--CONFIG_DFU_TFTP=y
--CONFIG_DFU_MMC=y
--CONFIG_DFU_RAM=y
--CONFIG_USB_FUNCTION_FASTBOOT=y
--CONFIG_FASTBOOT_FLASH=y
--CONFIG_FASTBOOT_FLASH_MMC_DEV=1
--CONFIG_FASTBOOT_CMD_OEM_FORMAT=y
-+# CONFIG_ENV_IS_IN_MMC is not set
-+CONFIG_ENV_IS_NOWHERE=y
-+# CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG is not set
-+# CONFIG_BOOTCOUNT_LIMIT is not set
-+# CONFIG_DFU_TFTP is not set
-+# CONFIG_DFU_MMC is not set
-+# CONFIG_DFU_RAM is not set
-+# CONFIG_USB_FUNCTION_FASTBOOT is not set
-+# CONFIG_FASTBOOT_FLASH is not set
-+# CONFIG_FASTBOOT_FLASH_MMC_DEV is not set
-+# CONFIG_FASTBOOT_CMD_OEM_FORMAT is not set
- CONFIG_MMC_OMAP_HS=y
--CONFIG_SPI_FLASH=y
--CONFIG_SPI_FLASH_WINBOND=y
--CONFIG_DRIVER_TI_CPSW=y
-+# CONFIG_SPI_FLASH is not set
-+# CONFIG_SPI_FLASH_WINBOND is not set
-+# CONFIG_DRIVER_TI_CPSW is not set
- CONFIG_SYS_NS16550=y
- CONFIG_SPI=y
- CONFIG_OMAP3_SPI=y
--CONFIG_USB=y
--CONFIG_USB_MUSB_HOST=y
--CONFIG_USB_MUSB_GADGET=y
--CONFIG_USB_MUSB_DSPS=y
--CONFIG_USB_STORAGE=y
--CONFIG_USB_GADGET=y
--CONFIG_USB_GADGET_MANUFACTURER="Texas Instruments"
--CONFIG_USB_GADGET_VENDOR_NUM=0x0451
--CONFIG_USB_GADGET_PRODUCT_NUM=0xd022
--CONFIG_USB_ETHER=y
--CONFIG_USBNET_HOST_ADDR="de:ad:be:af:00:00"
-+# CONFIG_USB is not set
- CONFIG_LZO=y
- CONFIG_OF_LIBFDT=y
 -- 
-2.7.4
+2.17.1
 


### PR DESCRIPTION
## Description

This reverts the U-boot patch to v2018.05, and drops most configs which cause the build to fail.

## Dependencies

Depends on https://github.com/eigendude/openembedded-core/pull/1

## How has this been tested?

Tested as part of https://github.com/eigendude/openembedded-core/pull/1